### PR TITLE
feat: 공지 조회 및 공지 목록 조회 시 슬랙채널 이름을 함께 반환한다.

### DIFF
--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/auth/AuthorizeUser.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/auth/AuthorizeUser.kt
@@ -1,6 +1,5 @@
 package com.woowahan.campus.announcement.auth
 
-import com.woowahan.campus.announcement.exception.AuthorizationException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
@@ -18,8 +17,8 @@ class AuthorizeUser(
         val authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
         val basicHeader = authorizationHeader.substringAfter("Basic ")
         val password = String(Base64.getDecoder().decode(basicHeader))
-        if (this.password != password) {
-            throw AuthorizationException("인증 오류")
+        require(this.password == password) {
+            "잘못된 비밀번호입니다."
         }
         return true
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/auth/AuthorizeUser.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/auth/AuthorizeUser.kt
@@ -1,5 +1,6 @@
 package com.woowahan.campus.announcement.auth
 
+import com.woowahan.campus.announcement.exception.AuthorizationException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
@@ -17,8 +18,8 @@ class AuthorizeUser(
         val authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION)
         val basicHeader = authorizationHeader.substringAfter("Basic ")
         val password = String(Base64.getDecoder().decode(basicHeader))
-        require(this.password == password) {
-            "잘못된 비밀번호입니다."
+        if (this.password != password) {
+            throw AuthorizationException("인증 오류")
         }
         return true
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -17,15 +17,16 @@ class Announcement(
 ) : BaseRootEntity<Announcement>(id) {
 
     fun update(title: String, content: String, author: String) {
+        require(this.author == Author(author)) {
+            "공지의 작성자만이 공지를 수정할 수 있습니다."
+        }
+        this.author = Author(author)
+
         require(title.isNotBlank() && content.isNotBlank() && author.isNotBlank()) {
             "공지의 제목, 내용, 작성자는 빈 칸으로 입력할 수 없습니다."
         }
         this.title = Title(title)
         this.content = Content(content)
-        require(this.author == Author(author)) {
-            "공지의 작성자만이 공지를 수정할 수 있습니다."
-        }
-        this.author = Author(author)
     }
 
     private fun publish(): Announcement {

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -17,17 +17,13 @@ class Announcement(
     id: Long = 0L,
 ) : BaseRootEntity<Announcement>(id) {
 
-    fun update(title: String, content: String, author: String) {
-        if (this.author != Author(author)) {
+    fun update(title: Title, content: Content, author: Author) {
+        if (this.author != author) {
             throw AuthorizationException("공지 작성자만이 공지를 수정할 수 있습니다.")
         }
-        this.author = Author(author)
-
-        require(title.isNotBlank() && content.isNotBlank() && author.isNotBlank()) {
-            "공지의 제목, 내용, 작성자는 빈 칸으로 입력할 수 없습니다."
-        }
-        this.title = Title(title)
-        this.content = Content(content)
+        this.title = title
+        this.content = content
+        this.author = author
     }
 
     private fun publish(): Announcement {

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -1,6 +1,5 @@
 package com.woowahan.campus.announcement.domain
 
-import com.woowahan.campus.announcement.exception.AuthorizationException
 import com.woowahan.campus.announcement.support.BaseRootEntity
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -23,8 +22,8 @@ class Announcement(
         }
         this.title = Title(title)
         this.content = Content(content)
-        if (this.author != Author(author)) {
-            throw AuthorizationException("공지 작성자만이 공지를 수정할 수 있습니다.")
+        require(this.author == Author(author)) {
+            "공지의 작성자만이 공지를 수정할 수 있습니다."
         }
         this.author = Author(author)
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -18,8 +18,8 @@ class Announcement(
 ) : BaseRootEntity<Announcement>(id) {
 
     fun update(title: String, content: String, author: String) {
-        if (title.isBlank() || content.isBlank() || author.isBlank()) {
-            throw IllegalArgumentException("공지의 제목, 내용, 작성자는 빈 칸으로 입력할 수 없습니다.")
+        require(title.isNotBlank() && content.isNotBlank() && author.isNotBlank()) {
+            "공지의 제목, 내용, 작성자는 빈 칸으로 입력할 수 없습니다."
         }
         this.title = Title(title)
         this.content = Content(content)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -1,5 +1,6 @@
 package com.woowahan.campus.announcement.domain
 
+import com.woowahan.campus.announcement.exception.AuthorizationException
 import com.woowahan.campus.announcement.support.BaseRootEntity
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
@@ -17,8 +18,8 @@ class Announcement(
 ) : BaseRootEntity<Announcement>(id) {
 
     fun update(title: String, content: String, author: String) {
-        require(this.author == Author(author)) {
-            "공지의 작성자만이 공지를 수정할 수 있습니다."
+        if (this.author != Author(author)) {
+            throw AuthorizationException("공지 작성자만이 공지를 수정할 수 있습니다.")
         }
         this.author = Author(author)
 
@@ -33,5 +34,4 @@ class Announcement(
         val event = MessageSendEvent(this)
         return this.andEvent(event)
     }
-
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -13,7 +13,7 @@ class Announcement(
     var content: Content,
     @Embedded
     var author: Author,
-    val slackChannelId: Int,
+    val slackChannelId: Long,
     id: Long = 0L,
 ) : BaseRootEntity<Announcement>(id) {
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Announcement.kt
@@ -34,8 +34,4 @@ class Announcement(
         return this.andEvent(event)
     }
 
-    companion object {
-        fun create(title: String, content: String, author: String, slackChannelId: Int): Announcement =
-            Announcement(Title(title), Content(content), Author(author), slackChannelId)
-    }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementRepository.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.repository.Repository
 
 interface AnnouncementRepository : Repository<Announcement, Long> {
 
-    fun findById(id: Long) : Announcement?
+    fun findById(id: Long): Announcement?
 
     fun save(announcement: Announcement): Announcement
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementSlackChannelRepository.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementSlackChannelRepository.kt
@@ -2,7 +2,11 @@ package com.woowahan.campus.announcement.domain
 
 import org.springframework.data.repository.Repository
 
+fun AnnouncementSlackChannelRepository.getById(id: Long) = findById(id)
+    ?: throw IllegalArgumentException("슬랙 채널을 찾을 수 없습니다.")
+
 interface AnnouncementSlackChannelRepository : Repository<AnnouncementSlackChannel, Long> {
     fun findById(id: Long): AnnouncementSlackChannel?
     fun existsById(id: Long): Boolean
+    fun save(announcementSlackChannel: AnnouncementSlackChannel): AnnouncementSlackChannel
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementValidator.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementValidator.kt
@@ -11,9 +11,9 @@ class AnnouncementValidator(
         title: String,
         content: String,
         author: String,
-        slackChannelId: Int,
+        slackChannelId: Long,
     ) {
-        require(announcementSlackChannelRepository.existsById(slackChannelId.toLong())) {
+        require(announcementSlackChannelRepository.existsById(slackChannelId)) {
             "존재하지 않는 슬랙 채널입니다."
         }
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementValidator.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/AnnouncementValidator.kt
@@ -1,6 +1,5 @@
 package com.woowahan.campus.announcement.domain
 
-import com.woowahan.campus.announcement.exception.SlackChannelNotFoundException
 import org.springframework.stereotype.Component
 
 @Component
@@ -14,12 +13,8 @@ class AnnouncementValidator(
         author: String,
         slackChannelId: Int,
     ) {
-        validateExistsSlackChannel(slackChannelId.toLong())
-    }
-
-    fun validateExistsSlackChannel(slackChannelId: Long) {
-        if (announcementSlackChannelRepository.existsById(slackChannelId)) {
-            throw SlackChannelNotFoundException("존재하지 않는 슬랙 채널입니다.")
+        require(announcementSlackChannelRepository.existsById(slackChannelId.toLong())) {
+            "존재하지 않는 슬랙 채널입니다."
         }
     }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
@@ -5,8 +5,7 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class Author(val author: String) {
     init {
-        val trimmedAuthor = author.trim()
-        require(trimmedAuthor.isNotEmpty() && trimmedAuthor.length <= MAX_LENGTH) {
+        require(author.isNotEmpty() && author.length <= MAX_LENGTH) {
             "공지의 작성자는 1자 이상, 20자 이하로 작성 가능합니다."
         }
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
@@ -3,25 +3,12 @@ package com.woowahan.campus.announcement.domain
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class Author(val author: String) {
+data class Author(val author: String) {
     init {
         val trimmedAuthor = author.trim()
         if (trimmedAuthor.isEmpty() || trimmedAuthor.length > MAX_LENGTH) {
             throw IllegalArgumentException("공지의 작성자는 1자 이상, 20자 이하로 작성 가능합니다.")
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Author
-
-        return author == other.author
-    }
-
-    override fun hashCode(): Int {
-        return author.hashCode()
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Author.kt
@@ -6,8 +6,8 @@ import jakarta.persistence.Embeddable
 data class Author(val author: String) {
     init {
         val trimmedAuthor = author.trim()
-        if (trimmedAuthor.isEmpty() || trimmedAuthor.length > MAX_LENGTH) {
-            throw IllegalArgumentException("공지의 작성자는 1자 이상, 20자 이하로 작성 가능합니다.")
+        require(trimmedAuthor.isNotEmpty() && trimmedAuthor.length <= MAX_LENGTH) {
+            "공지의 작성자는 1자 이상, 20자 이하로 작성 가능합니다."
         }
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
@@ -3,25 +3,12 @@ package com.woowahan.campus.announcement.domain
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class Content(val content: String) {
+data class Content(val content: String) {
     init {
         val trimmedContent = content.trim()
         if (trimmedContent.isEmpty() || trimmedContent.length > MAX_LENGTH) {
             throw IllegalArgumentException("공지의 내용은 1자 이상, 65,535자 이하로 작성 가능합니다.")
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Content
-
-        return content == other.content
-    }
-
-    override fun hashCode(): Int {
-        return content.hashCode()
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
@@ -6,8 +6,8 @@ import jakarta.persistence.Embeddable
 data class Content(val content: String) {
     init {
         val trimmedContent = content.trim()
-        if (trimmedContent.isEmpty() || trimmedContent.length > MAX_LENGTH) {
-            throw IllegalArgumentException("공지의 내용은 1자 이상, 65,535자 이하로 작성 가능합니다.")
+        require(trimmedContent.isNotEmpty() && trimmedContent.length <= MAX_LENGTH) {
+            "공지의 내용은 1자 이상, 65,535자 이하로 작성 가능합니다."
         }
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Content.kt
@@ -5,8 +5,7 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class Content(val content: String) {
     init {
-        val trimmedContent = content.trim()
-        require(trimmedContent.isNotEmpty() && trimmedContent.length <= MAX_LENGTH) {
+        require(content.isNotEmpty() && content.length <= MAX_LENGTH) {
             "공지의 내용은 1자 이상, 65,535자 이하로 작성 가능합니다."
         }
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/MessageSendEvent.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/MessageSendEvent.kt
@@ -3,7 +3,7 @@ package com.woowahan.campus.announcement.domain
 data class MessageSendEvent(
     val announcement: Announcement,
 ) {
-    val channelId = announcement.slackChannelId.toLong()
+    val channelId = announcement.slackChannelId
     val author = announcement.author.author
     val content = announcement.content.content
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
@@ -3,25 +3,12 @@ package com.woowahan.campus.announcement.domain
 import jakarta.persistence.Embeddable
 
 @Embeddable
-class Title(val title: String) {
+data class Title(val title: String) {
     init {
         val trimmedTitle = title.trim()
         if (trimmedTitle.isEmpty() || trimmedTitle.length > MAX_LENGTH) {
             throw IllegalArgumentException("공지의 제목은 1자 이상, 50자 이하로 작성 가능합니다.")
         }
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as Title
-
-        return title == other.title
-    }
-
-    override fun hashCode(): Int {
-        return title.hashCode()
     }
 
     companion object {

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
@@ -6,8 +6,8 @@ import jakarta.persistence.Embeddable
 data class Title(val title: String) {
     init {
         val trimmedTitle = title.trim()
-        if (trimmedTitle.isEmpty() || trimmedTitle.length > MAX_LENGTH) {
-            throw IllegalArgumentException("공지의 제목은 1자 이상, 50자 이하로 작성 가능합니다.")
+        require(trimmedTitle.isNotEmpty() && trimmedTitle.length <= MAX_LENGTH) {
+            "공지의 제목은 1자 이상, 50자 이하로 작성 가능합니다."
         }
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/domain/Title.kt
@@ -5,8 +5,7 @@ import jakarta.persistence.Embeddable
 @Embeddable
 data class Title(val title: String) {
     init {
-        val trimmedTitle = title.trim()
-        require(trimmedTitle.isNotEmpty() && trimmedTitle.length <= MAX_LENGTH) {
+        require(title.isNotEmpty() && title.length <= MAX_LENGTH) {
             "공지의 제목은 1자 이상, 50자 이하로 작성 가능합니다."
         }
     }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.woowahan.campus.announcement.exception
 
 import org.springdoc.api.ErrorMessage
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -8,8 +9,13 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 @ControllerAdvice
 class AnnouncementExceptionHandler {
 
-    @ExceptionHandler
-    fun handleAnnouncementNotFoundException(exception: IllegalArgumentException): ResponseEntity<ErrorMessage> {
+    @ExceptionHandler(IllegalArgumentException::class, IllegalStateException::class)
+    fun handleBadRequestException(exception: RuntimeException): ResponseEntity<ErrorMessage> {
         return ResponseEntity.badRequest().body(ErrorMessage(exception.message))
+    }
+
+    @ExceptionHandler(AuthorizationException::class)
+    fun handleUnauthorizedException(exception: AuthorizationException): ResponseEntity<ErrorMessage> {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorMessage(exception.message))
     }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
@@ -12,5 +12,4 @@ class AnnouncementExceptionHandler {
     fun handleAnnouncementNotFoundException(exception: IllegalArgumentException): ResponseEntity<ErrorMessage> {
         return ResponseEntity.badRequest().body(ErrorMessage(exception.message))
     }
-
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementExceptionHandler.kt
@@ -1,7 +1,6 @@
 package com.woowahan.campus.announcement.exception
 
 import org.springdoc.api.ErrorMessage
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -10,12 +9,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class AnnouncementExceptionHandler {
 
     @ExceptionHandler
-    fun handleAnnouncementNotFoundException(exception: AnnouncementNotFoundException): ResponseEntity<ErrorMessage> {
+    fun handleAnnouncementNotFoundException(exception: IllegalArgumentException): ResponseEntity<ErrorMessage> {
         return ResponseEntity.badRequest().body(ErrorMessage(exception.message))
     }
 
-    @ExceptionHandler
-    fun handleAuthorizationException(exception: AuthorizationException): ResponseEntity<ErrorMessage> {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorMessage(exception.message))
-    }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementNotFoundException.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AnnouncementNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.woowahan.campus.announcement.exception
-
-class AnnouncementNotFoundException(message: String) : Exception(message)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AuthorizationException.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AuthorizationException.kt
@@ -1,3 +1,0 @@
-package com.woowahan.campus.announcement.exception
-
-class AuthorizationException(message: String) : Throwable(message)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AuthorizationException.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/AuthorizationException.kt
@@ -1,0 +1,3 @@
+package com.woowahan.campus.announcement.exception
+
+class AuthorizationException(message: String) : RuntimeException(message)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/SlackChannelNotFoundException.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/SlackChannelNotFoundException.kt
@@ -1,3 +1,0 @@
-package com.woowahan.campus.announcement.exception
-
-class SlackChannelNotFoundException(message: String) : Exception(message)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/UnauthorizedUserException.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/exception/UnauthorizedUserException.kt
@@ -1,3 +1,0 @@
-package com.woowahan.campus.announcement.exception
-
-class UnauthorizedUserException(message: String) : Exception(message)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/CreateAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/CreateAnnouncement.kt
@@ -2,6 +2,9 @@ package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.Announcement
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
+import com.woowahan.campus.announcement.domain.Author
+import com.woowahan.campus.announcement.domain.Content
+import com.woowahan.campus.announcement.domain.Title
 import openapi.api.CreateAnnouncementApi
 import openapi.model.CreateAnnouncementRequest
 import org.springframework.http.ResponseEntity
@@ -21,10 +24,10 @@ class CreateAnnouncement(
     ): ResponseEntity<Unit> {
 
         val savedAnnouncement = announcementRepository.save(
-            Announcement.create(
-                createAnnouncementRequest.title,
-                createAnnouncementRequest.content,
-                createAnnouncementRequest.author,
+            Announcement(
+                Title(createAnnouncementRequest.title),
+                Content(createAnnouncementRequest.content),
+                Author(createAnnouncementRequest.author),
                 createAnnouncementRequest.slackChannel.channelId,
             )
         )

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/DeleteAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/DeleteAnnouncement.kt
@@ -1,7 +1,6 @@
 package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
-import com.woowahan.campus.announcement.exception.AnnouncementNotFoundException
 import openapi.api.DeleteAnnouncementApi
 import org.springframework.http.ResponseEntity
 import org.springframework.transaction.annotation.Transactional
@@ -14,8 +13,8 @@ class DeleteAnnouncement(
 
     @Transactional
     override fun deleteAnnouncement(id: Long, authorization: String): ResponseEntity<Unit> {
-        if (!announcementRepository.existsById(id)) {
-            throw AnnouncementNotFoundException("존재하지 않는 announcement입니다.")
+        require(announcementRepository.existsById(id)) {
+            "존재하지 않는 announcement입니다."
         }
 
         announcementRepository.deleteById(id)

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
@@ -2,6 +2,8 @@ package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.Announcement
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
+import com.woowahan.campus.announcement.domain.AnnouncementSlackChannelRepository
+import com.woowahan.campus.announcement.domain.getById
 import openapi.api.GetAllAnnouncementApi
 import openapi.model.AnnouncementInfoResponse
 import openapi.model.AnnouncementsInfoByCursorResponse
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController
 @Transactional(readOnly = true)
 class GetAllAnnouncement(
     private val announcementRepository: AnnouncementRepository,
+    private val announcementSlackChannelRepository: AnnouncementSlackChannelRepository,
 ) : GetAllAnnouncementApi {
 
     override fun findAllAnnouncementByOffset(
@@ -42,7 +45,8 @@ class GetAllAnnouncement(
             announcement.id,
             announcement.title.title,
             announcement.author.author,
-            announcement.createdAt.toString()
+            announcement.createdAt.toString(),
+            announcementSlackChannelRepository.getById(announcement.slackChannelId).name
         )
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
@@ -15,8 +15,10 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @Transactional(readOnly = true)
-class GetAllAnnouncement(private val announcementRepository: AnnouncementRepository) : GetAllAnnouncementApi {
-    //TODO: 패스워드 레포지터리 및 디코더 구현
+class GetAllAnnouncement(
+    private val announcementRepository: AnnouncementRepository,
+) : GetAllAnnouncementApi {
+
     override fun findAllAnnouncementByOffset(
         authorization: String,
         page: Int,
@@ -46,11 +48,11 @@ class GetAllAnnouncement(private val announcementRepository: AnnouncementReposit
 
     override fun findAllAnnouncementByCursor(
         authorization: String,
-        cursorId: Long,
+        cursorId: Int,
         size: Int
     ): ResponseEntity<AnnouncementsInfoByCursorResponse> {
         val pageRequest = PageRequest.of(0, size)
-        val announcements: Slice<Announcement> = getAnnouncements(cursorId, pageRequest)
+        val announcements: Slice<Announcement> = getAnnouncements(cursorId.toLong(), pageRequest)
 
         return ResponseEntity.ok(
             AnnouncementsInfoByCursorResponse(

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
@@ -35,8 +35,8 @@ class GetAllAnnouncement(
                 announcements.number,
                 announcements.size,
                 announcements.totalElements.toInt(),
-                announcements.totalPages
-            )
+                announcements.totalPages,
+            ),
         )
     }
 
@@ -46,14 +46,14 @@ class GetAllAnnouncement(
             announcement.title.title,
             announcement.author.author,
             announcement.createdAt.toString(),
-            announcementSlackChannelRepository.getById(announcement.slackChannelId).name
+            announcementSlackChannelRepository.getById(announcement.slackChannelId).name,
         )
     }
 
     override fun findAllAnnouncementByCursor(
         authorization: String,
         cursorId: Int,
-        size: Int
+        size: Int,
     ): ResponseEntity<AnnouncementsInfoByCursorResponse> {
         val pageRequest = PageRequest.of(0, size)
         val announcements: Slice<Announcement> = getAnnouncements(cursorId.toLong(), pageRequest)
@@ -62,8 +62,8 @@ class GetAllAnnouncement(
             AnnouncementsInfoByCursorResponse(
                 announcements.get().map(::toAnnouncementPageResponses).toList(),
                 announcements.hasNext(),
-                announcements.last().id
-            )
+                announcements.last().id,
+            ),
         )
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncement.kt
@@ -37,7 +37,7 @@ class GetAllAnnouncement(private val announcementRepository: AnnouncementReposit
 
     fun toAnnouncementPageResponses(announcement: Announcement): AnnouncementInfoResponse {
         return AnnouncementInfoResponse(
-            announcement.id.toInt(),
+            announcement.id,
             announcement.title.title,
             announcement.author.author,
             announcement.createdAt.toString()
@@ -46,7 +46,7 @@ class GetAllAnnouncement(private val announcementRepository: AnnouncementReposit
 
     override fun findAllAnnouncementByCursor(
         authorization: String,
-        cursorId: Int,
+        cursorId: Long,
         size: Int
     ): ResponseEntity<AnnouncementsInfoByCursorResponse> {
         val pageRequest = PageRequest.of(0, size)
@@ -56,15 +56,15 @@ class GetAllAnnouncement(private val announcementRepository: AnnouncementReposit
             AnnouncementsInfoByCursorResponse(
                 announcements.get().map(::toAnnouncementPageResponses).toList(),
                 announcements.hasNext(),
-                announcements.last().id.toInt()
+                announcements.last().id
             )
         )
     }
 
-    fun getAnnouncements(cursorId: Int, pageRequest: PageRequest): Slice<Announcement> {
+    fun getAnnouncements(cursorId: Long, pageRequest: PageRequest): Slice<Announcement> {
         return when (cursorId) {
-            0 -> announcementRepository.findByOrderByIdDesc(pageRequest)
-            else -> announcementRepository.findByIdLessThanOrderByIdDesc(cursorId.toLong(), pageRequest)
+            0L -> announcementRepository.findByOrderByIdDesc(pageRequest)
+            else -> announcementRepository.findByIdLessThanOrderByIdDesc(cursorId, pageRequest)
         }
     }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
@@ -30,7 +30,7 @@ class GetAnnouncement(
             announcement.content.content,
             announcement.author.author,
             announcement.createdAt.toString(),
-            announcementSlackChannelRepository.getById(announcement.slackChannelId).name
+            announcementSlackChannelRepository.getById(announcement.slackChannelId).name,
         )
     }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
@@ -2,6 +2,8 @@ package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.Announcement
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
+import com.woowahan.campus.announcement.domain.AnnouncementSlackChannelRepository
+import com.woowahan.campus.announcement.domain.getById
 import openapi.api.GetAnnouncementApi
 import openapi.model.AnnouncementResponse
 import org.springframework.http.ResponseEntity
@@ -11,7 +13,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @Transactional(readOnly = true)
 class GetAnnouncement(
-    val announcementRepository: AnnouncementRepository
+    val announcementRepository: AnnouncementRepository,
+    val announcementSlackChannelRepository: AnnouncementSlackChannelRepository,
 ) : GetAnnouncementApi {
 
     override fun findAnnouncementById(id: Long, authorization: String): ResponseEntity<AnnouncementResponse> {
@@ -27,6 +30,7 @@ class GetAnnouncement(
             announcement.content.content,
             announcement.author.author,
             announcement.createdAt.toString(),
+            announcementSlackChannelRepository.getById(announcement.slackChannelId).name
         )
     }
 }

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
@@ -2,7 +2,6 @@ package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.Announcement
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
-import com.woowahan.campus.announcement.exception.AnnouncementNotFoundException
 import openapi.api.GetAnnouncementApi
 import openapi.model.AnnouncementResponse
 import org.springframework.http.ResponseEntity
@@ -17,7 +16,7 @@ class GetAnnouncement(
 
     override fun findAnnouncementById(id: Long, authorization: String): ResponseEntity<AnnouncementResponse> {
         val announcement = announcementRepository.findById(id)
-            ?: throw AnnouncementNotFoundException("존재하지 않는 announcement입니다.")
+            ?: throw IllegalArgumentException("존재하지 않는 announcement입니다.")
         return ResponseEntity.ok().body(toResponse(announcement))
     }
 

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/GetAnnouncement.kt
@@ -22,7 +22,7 @@ class GetAnnouncement(
 
     private fun toResponse(announcement: Announcement): AnnouncementResponse {
         return AnnouncementResponse(
-            announcement.id.toInt(),
+            announcement.id,
             announcement.title.title,
             announcement.content.content,
             announcement.author.author,

--- a/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/UpdateAnnouncement.kt
+++ b/backend/src/main/kotlin/com/woowahan/campus/announcement/feature/UpdateAnnouncement.kt
@@ -1,6 +1,9 @@
 package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
+import com.woowahan.campus.announcement.domain.Author
+import com.woowahan.campus.announcement.domain.Content
+import com.woowahan.campus.announcement.domain.Title
 import openapi.api.UpdateAnnouncementApi
 import openapi.model.UpdateAnnouncementRequest
 import org.springframework.http.ResponseEntity
@@ -22,9 +25,9 @@ class UpdateAnnouncement(
             ?: throw NoSuchElementException("수정하려는 공지가 존재하지 않습니다.")
 
         announcement.update(
-            updateAnnouncementRequest.title,
-            updateAnnouncementRequest.content,
-            updateAnnouncementRequest.author
+            Title(updateAnnouncementRequest.title),
+            Content(updateAnnouncementRequest.content),
+            Author(updateAnnouncementRequest.author)
         )
 
         // TODO: 슬랙 API 호출

--- a/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
@@ -1,9 +1,9 @@
 package com.woowahan.campus.announcement.feature
 
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
-import com.woowahan.campus.fixture.createAnnouncement
-import com.woowahan.campus.fixture.createAnnouncementsInfoByCursorResponse
-import com.woowahan.campus.fixture.createAnnouncementsInfoByOffsetResponse
+import com.woowahan.campus.announcement.domain.AnnouncementSlackChannel
+import com.woowahan.campus.announcement.domain.AnnouncementSlackChannelRepository
+import com.woowahan.campus.fixture.*
 import com.woowahan.campus.utils.DatabaseCleaner
 import com.woowahan.campus.utils.basicEncodePassword
 import io.kotest.core.spec.style.BehaviorSpec
@@ -27,6 +27,7 @@ class GetAllAnnouncementTest(
     @LocalServerPort
     private val port: Int,
     private val announcementRepository: AnnouncementRepository,
+    private val announcementSlackChannelRepository: AnnouncementSlackChannelRepository,
     private val databaseCleaner: DatabaseCleaner
 
 ) : BehaviorSpec({
@@ -38,14 +39,14 @@ class GetAllAnnouncementTest(
     }
 
     Given("등록된 공지가 20개가 있을 때") {
-
+        val slackChannel = announcementSlackChannelRepository.save(AnnouncementSlackChannel("CK01", "6기-공지사항"))
         val announcements = (1..20).map { count ->
             announcementRepository.save(
                 createAnnouncement(
                     "${count}번 째 공지",
                     "${count}번 째 공지입니다.",
                     "작성자",
-                    1
+                    slackChannel.id
                 )
             )
         }.toList()
@@ -59,7 +60,7 @@ class GetAllAnnouncementTest(
             Then("해당 페이지에 존재하는 공지의 id, 제목, 작성자, 작성일 목록을 요청 개수 만큼 반환한다.") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByOffsetResponse(
-                    announcements.slice(5..9),
+                    createAnnouncementInfoResponses(announcements.slice(5..9), slackChannel),
                     1,
                     5,
                     20,
@@ -77,7 +78,7 @@ class GetAllAnnouncementTest(
             Then("0번째 페이지가 반환된다.") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByOffsetResponse(
-                    announcements.slice(0..4),
+                    createAnnouncementInfoResponses(announcements.slice(0..4), slackChannel),
                     0,
                     5,
                     20,
@@ -95,7 +96,7 @@ class GetAllAnnouncementTest(
             Then("해당 페이지의 10개의 공지 목록이 반환된다.") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByOffsetResponse(
-                    announcements.slice(10..19),
+                    createAnnouncementInfoResponses(announcements.slice(10..19), slackChannel),
                     1,
                     10,
                     20,
@@ -113,7 +114,7 @@ class GetAllAnnouncementTest(
             Then("제일 최신 공지만 요청한 개수만큼 반환한다") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByCursorResponse(
-                    announcements.slice(19 downTo 10),
+                    createAnnouncementInfoResponses(announcements.slice(19 downTo 10), slackChannel),
                     true,
                     11,
                 )
@@ -129,7 +130,7 @@ class GetAllAnnouncementTest(
             Then("마지막으로 본 공지 ID 다음 공지부터 공지개수 만큼 반환한다.") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByCursorResponse(
-                    announcements.slice(4 downTo 2),
+                    createAnnouncementInfoResponses(announcements.slice(4 downTo 2), slackChannel),
                     true,
                     3,
                 )
@@ -145,7 +146,7 @@ class GetAllAnnouncementTest(
             Then("남은 공지 목록과 다음 공지는 없다는 응답을 반환한다") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByCursorResponse(
-                    announcements.slice(4 downTo 0),
+                    createAnnouncementInfoResponses(announcements.slice(4 downTo 0), slackChannel),
                     false,
                     1,
                 )
@@ -161,7 +162,7 @@ class GetAllAnnouncementTest(
             Then("0번째 페이지의 10개의 공지 목록을 조회한다.") {
                 response.statusCode() shouldBe 200
                 responseBody shouldBeEqualToComparingFields createAnnouncementsInfoByOffsetResponse(
-                    announcements.slice(0..9),
+                    createAnnouncementInfoResponses(announcements.slice(0..9), slackChannel),
                     0,
                     10,
                     20,

--- a/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
@@ -107,7 +107,7 @@ class GetAllAnnouncementTest(
         When("커서 방식을 통해 옳바른 비밀번호와 조회하려는 공지 개수만 요청하면") {
 
             val queryStrings = mapOf(Pair("size", 10))
-            val response = sendRequest("/api/announcements/cursor", queryStrings, "1234")
+            val response = sendRequest("/api/announcements/cursor?size=10", queryStrings, "1234")
             val responseBody = response.`as`(AnnouncementsInfoByCursorResponse::class.java)
 
             Then("제일 최신 공지만 요청한 개수만큼 반환한다") {

--- a/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/GetAllAnnouncementTest.kt
@@ -3,7 +3,10 @@ package com.woowahan.campus.announcement.feature
 import com.woowahan.campus.announcement.domain.AnnouncementRepository
 import com.woowahan.campus.announcement.domain.AnnouncementSlackChannel
 import com.woowahan.campus.announcement.domain.AnnouncementSlackChannelRepository
-import com.woowahan.campus.fixture.*
+import com.woowahan.campus.fixture.createAnnouncement
+import com.woowahan.campus.fixture.createAnnouncementInfoResponses
+import com.woowahan.campus.fixture.createAnnouncementsInfoByCursorResponse
+import com.woowahan.campus.fixture.createAnnouncementsInfoByOffsetResponse
 import com.woowahan.campus.utils.DatabaseCleaner
 import com.woowahan.campus.utils.basicEncodePassword
 import io.kotest.core.spec.style.BehaviorSpec
@@ -28,7 +31,7 @@ class GetAllAnnouncementTest(
     private val port: Int,
     private val announcementRepository: AnnouncementRepository,
     private val announcementSlackChannelRepository: AnnouncementSlackChannelRepository,
-    private val databaseCleaner: DatabaseCleaner
+    private val databaseCleaner: DatabaseCleaner,
 
 ) : BehaviorSpec({
 
@@ -46,8 +49,8 @@ class GetAllAnnouncementTest(
                     "${count}번 째 공지",
                     "${count}번 째 공지입니다.",
                     "작성자",
-                    slackChannel.id
-                )
+                    slackChannel.id,
+                ),
             )
         }.toList()
 
@@ -64,7 +67,7 @@ class GetAllAnnouncementTest(
                     1,
                     5,
                     20,
-                    4
+                    4,
                 )
             }
         }
@@ -82,7 +85,7 @@ class GetAllAnnouncementTest(
                     0,
                     5,
                     20,
-                    4
+                    4,
                 )
             }
         }
@@ -100,7 +103,7 @@ class GetAllAnnouncementTest(
                     1,
                     10,
                     20,
-                    2
+                    2,
                 )
             }
         }
@@ -166,7 +169,7 @@ class GetAllAnnouncementTest(
                     0,
                     10,
                     20,
-                    2
+                    2,
                 )
             }
         }

--- a/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/UpdateAnnouncementTest.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/announcement/feature/UpdateAnnouncementTest.kt
@@ -54,7 +54,7 @@ class UpdateAnnouncementTest(
         }
     }
 
-    Given("글ID, 제목, 내용, 작성자, 관리자 비밀번호를 받는다.") {
+    Given("글ID, 제목, 내용, 실제 작성자와 다른 작성자, 관리자 비밀번호를 받는다.") {
         val password = "1234".toByteArray()
         val savedAnnouncementId = createAnnouncement(password, createAnnouncementRequest(author = "author"))
 
@@ -89,4 +89,4 @@ private fun createAnnouncement(
     .then().log().all()
     .extract()
     .header(HttpHeaders.LOCATION)
-    .split("/").last().toInt()
+    .split("/").last().toLong()

--- a/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
@@ -15,7 +15,7 @@ fun createAnnouncement(
     title: String,
     content: String,
     author: String,
-    slackChannelId: Int,
+    slackChannelId: Long,
     id: Long = 0L,
 ): Announcement {
     return Announcement(Title(title), Content(content), Author(author), slackChannelId, id)
@@ -40,7 +40,7 @@ fun createAnnouncementsInfoByOffsetResponse(
 fun createAnnouncementsInfoByCursorResponse(
     announcements: List<Announcement>,
     hasNext: Boolean,
-    lastCursorId: Int,
+    lastCursorId: Long,
 ): AnnouncementsInfoByCursorResponse {
     return AnnouncementsInfoByCursorResponse(
         announcements.map { createAnnouncementInfoResponse(it) },
@@ -51,7 +51,7 @@ fun createAnnouncementsInfoByCursorResponse(
 
 fun createAnnouncementInfoResponse(announcement: Announcement): AnnouncementInfoResponse {
     return AnnouncementInfoResponse(
-        announcement.id.toInt(),
+        announcement.id,
         announcement.title.title,
         announcement.author.author,
         announcement.createdAt.toString()
@@ -62,7 +62,7 @@ fun createAnnouncementRequest(
     title: String = "title",
     content: String = "content",
     author: String,
-    slackChannelId: Int = 1,
+    slackChannelId: Long = 1L,
     slackChannelName: String = "slackChannelName"
 ): CreateAnnouncementRequest {
     return CreateAnnouncementRequest(

--- a/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
@@ -1,15 +1,7 @@
 package com.woowahan.campus.fixture
 
-import com.woowahan.campus.announcement.domain.Announcement
-import com.woowahan.campus.announcement.domain.Author
-import com.woowahan.campus.announcement.domain.Content
-import com.woowahan.campus.announcement.domain.Title
-import openapi.model.AnnouncementInfoResponse
-import openapi.model.AnnouncementsInfoByCursorResponse
-import openapi.model.AnnouncementsInfoByOffsetResponse
-import openapi.model.CreateAnnouncementRequest
-import openapi.model.CreateAnnouncementRequestSlackChannel
-import openapi.model.UpdateAnnouncementRequest
+import com.woowahan.campus.announcement.domain.*
+import openapi.model.*
 
 fun createAnnouncement(
     title: String,
@@ -22,14 +14,14 @@ fun createAnnouncement(
 }
 
 fun createAnnouncementsInfoByOffsetResponse(
-    announcements: List<Announcement>,
+    announcements: List<AnnouncementInfoResponse>,
     page: Int,
     size: Int,
     totalElements: Int,
     totalPages: Int,
 ): AnnouncementsInfoByOffsetResponse {
     return AnnouncementsInfoByOffsetResponse(
-        announcements.map { createAnnouncementInfoResponse(it) },
+        announcements,
         page,
         size,
         totalElements,
@@ -38,23 +30,34 @@ fun createAnnouncementsInfoByOffsetResponse(
 }
 
 fun createAnnouncementsInfoByCursorResponse(
-    announcements: List<Announcement>,
+    announcements: List<AnnouncementInfoResponse>,
     hasNext: Boolean,
     lastCursorId: Long,
 ): AnnouncementsInfoByCursorResponse {
     return AnnouncementsInfoByCursorResponse(
-        announcements.map { createAnnouncementInfoResponse(it) },
+        announcements,
         hasNext,
         lastCursorId
     )
 }
 
-fun createAnnouncementInfoResponse(announcement: Announcement): AnnouncementInfoResponse {
+fun createAnnouncementInfoResponses(
+    announcements: List<Announcement>,
+    slackChannel: AnnouncementSlackChannel
+): List<AnnouncementInfoResponse> {
+    return announcements.map { createAnnouncementInfoResponse(it, slackChannel) }
+}
+
+fun createAnnouncementInfoResponse(
+    announcement: Announcement,
+    slackChannel: AnnouncementSlackChannel
+): AnnouncementInfoResponse {
     return AnnouncementInfoResponse(
         announcement.id,
         announcement.title.title,
         announcement.author.author,
-        announcement.createdAt.toString()
+        announcement.createdAt.toString(),
+        slackChannel.name
     )
 }
 
@@ -70,6 +73,20 @@ fun createAnnouncementRequest(
         content,
         author,
         CreateAnnouncementRequestSlackChannel(slackChannelId, slackChannelName)
+    )
+}
+
+fun createAnnouncementResponse(
+    announcement: Announcement,
+    slackChannel: AnnouncementSlackChannel
+): AnnouncementResponse {
+    return AnnouncementResponse(
+        announcement.id,
+        announcement.title.title,
+        announcement.content.content,
+        announcement.author.author,
+        announcement.createdAt.toString(),
+        slackChannel.name
     )
 }
 

--- a/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/fixture/AnnouncementFixture.kt
@@ -1,7 +1,17 @@
 package com.woowahan.campus.fixture
 
-import com.woowahan.campus.announcement.domain.*
-import openapi.model.*
+import com.woowahan.campus.announcement.domain.Announcement
+import com.woowahan.campus.announcement.domain.AnnouncementSlackChannel
+import com.woowahan.campus.announcement.domain.Author
+import com.woowahan.campus.announcement.domain.Content
+import com.woowahan.campus.announcement.domain.Title
+import openapi.model.AnnouncementInfoResponse
+import openapi.model.AnnouncementResponse
+import openapi.model.AnnouncementsInfoByCursorResponse
+import openapi.model.AnnouncementsInfoByOffsetResponse
+import openapi.model.CreateAnnouncementRequest
+import openapi.model.CreateAnnouncementRequestSlackChannel
+import openapi.model.UpdateAnnouncementRequest
 
 fun createAnnouncement(
     title: String,
@@ -25,7 +35,7 @@ fun createAnnouncementsInfoByOffsetResponse(
         page,
         size,
         totalElements,
-        totalPages
+        totalPages,
     )
 }
 
@@ -37,27 +47,27 @@ fun createAnnouncementsInfoByCursorResponse(
     return AnnouncementsInfoByCursorResponse(
         announcements,
         hasNext,
-        lastCursorId
+        lastCursorId,
     )
 }
 
 fun createAnnouncementInfoResponses(
     announcements: List<Announcement>,
-    slackChannel: AnnouncementSlackChannel
+    slackChannel: AnnouncementSlackChannel,
 ): List<AnnouncementInfoResponse> {
     return announcements.map { createAnnouncementInfoResponse(it, slackChannel) }
 }
 
 fun createAnnouncementInfoResponse(
     announcement: Announcement,
-    slackChannel: AnnouncementSlackChannel
+    slackChannel: AnnouncementSlackChannel,
 ): AnnouncementInfoResponse {
     return AnnouncementInfoResponse(
         announcement.id,
         announcement.title.title,
         announcement.author.author,
         announcement.createdAt.toString(),
-        slackChannel.name
+        slackChannel.name,
     )
 }
 
@@ -66,19 +76,19 @@ fun createAnnouncementRequest(
     content: String = "content",
     author: String,
     slackChannelId: Long = 1L,
-    slackChannelName: String = "slackChannelName"
+    slackChannelName: String = "slackChannelName",
 ): CreateAnnouncementRequest {
     return CreateAnnouncementRequest(
         title,
         content,
         author,
-        CreateAnnouncementRequestSlackChannel(slackChannelId, slackChannelName)
+        CreateAnnouncementRequestSlackChannel(slackChannelId, slackChannelName),
     )
 }
 
 fun createAnnouncementResponse(
     announcement: Announcement,
-    slackChannel: AnnouncementSlackChannel
+    slackChannel: AnnouncementSlackChannel,
 ): AnnouncementResponse {
     return AnnouncementResponse(
         announcement.id,
@@ -86,14 +96,14 @@ fun createAnnouncementResponse(
         announcement.content.content,
         announcement.author.author,
         announcement.createdAt.toString(),
-        slackChannel.name
+        slackChannel.name,
     )
 }
 
 fun createUpdateAnnouncementRequest(
     title: String = "updateTitle",
     content: String = "updateContent",
-    author: String
+    author: String,
 ): UpdateAnnouncementRequest {
     return UpdateAnnouncementRequest(title, content, author)
 }

--- a/backend/src/test/kotlin/com/woowahan/campus/utils/DatabaseCleaner.kt
+++ b/backend/src/test/kotlin/com/woowahan/campus/utils/DatabaseCleaner.kt
@@ -23,7 +23,7 @@ class DatabaseCleaner : InitializingBean {
     @Transactional
     fun clean() {
         executeQuery("SET REFERENTIAL_INTEGRITY FALSE")
-        tableNames.forEach { executeQuery("TRUNCATE TABLE ${it} RESTART IDENTITY") }
+        tableNames.forEach { executeQuery("TRUNCATE TABLE $it RESTART IDENTITY") }
 
         executeQuery("SET REFERENTIAL_INTEGRITY TRUE")
     }

--- a/docs/contract/campus-platform-contract.yaml
+++ b/docs/contract/campus-platform-contract.yaml
@@ -104,6 +104,7 @@ paths:
           name: cursorId
           schema:
             type: integer
+            format: int64
             example: 0
             default: 0
           required: false
@@ -242,6 +243,7 @@ components:
           properties:
             channelId:
               type: integer
+              format: int64
               example: 1
               nullable: false
             channelName:
@@ -289,6 +291,7 @@ components:
       properties:
         id:
           type: integer
+          format: int64
           example: 1
         title:
           type: string
@@ -348,6 +351,7 @@ components:
           example: false
         lastCursorId:
           type: integer
+          format: int64
           example: 10
       required:
         - announcements
@@ -358,6 +362,7 @@ components:
       properties:
         id:
           type: integer
+          format: int64
           example: 1
         title:
           type: string

--- a/docs/contract/campus-platform-contract.yaml
+++ b/docs/contract/campus-platform-contract.yaml
@@ -307,6 +307,9 @@ components:
         createdAt:
           type: string
           example: '2021-08-01T00:00:00.000'
+        slackChannel:
+          type: string
+          example: '6기-공지사항'
       required:
         - id
         - title
@@ -374,6 +377,9 @@ components:
         createdAt:
           type: string
           example: '2021-08-01T00:00:00.000'
+        slackChannel:
+          type: string
+          example: '6기-공지사항'
       required:
         - id
         - title

--- a/docs/contract/campus-platform-contract.yaml
+++ b/docs/contract/campus-platform-contract.yaml
@@ -104,7 +104,6 @@ paths:
           name: cursorId
           schema:
             type: integer
-            format: int64
             example: 0
             default: 0
           required: false


### PR DESCRIPTION
### 👨🏻‍💻 작업 사항
공지 단건 조회 및 공지 목록 조회 시 슬랙 채널 이름을 함께 반환하도록 추가하였습니다.
[리뷰 범위](https://github.com/Songusika/woowa-announcement-attendance/pull/13/files/721ae848429a8632f1fd904ba4368574f3996db4..554e1438f34d35ea39a22561d5dea9e73ba8eee3)

### 💬 기타 사항
#### openApi generator - `int64` 포맷 이슈
![image](https://github.com/Songusika/woowa-announcement-attendance/assets/74398096/5a5ae0fb-c50c-41e0-a5ab-b905252759e7)
위 사진과 같이 `int64` 로 데이터 포맷 사용하고 default 값을 사용하면 컨트롤러 단에서 아래와 같이 매핑이 됩니다.
![image](https://github.com/Songusika/woowa-announcement-attendance/assets/74398096/6d670f3f-e100-408a-848c-4c40ae30e48d)

`Long` 타입의 `defaultValue`는 뒤에 `L` 문자열이 없어야하기 때문에 런타임 에러가 발생합니다.
따라서 필요한 부분만 `int64` 포맷을 사용할 것인지,
데이터포맷을 명시하지 않고 각 컨트롤러에서 직접 `toLong()` 을 호출할 건지 이야기해보면 좋을것 같아요!